### PR TITLE
feat: increase minimum Python version to 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.12"]
         project-type: ["app", "package"]
 
     name: Python ${{ matrix.python-version }} ${{ matrix.project-type }}
@@ -27,12 +27,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Scaffold Python project
         run: |
           pip install --no-input cruft
-          cruft create --no-input --extra-context '{"project_type": "${{ matrix.project-type }}", "project_name": "My Project", "python_version": "3.9", "__docker_image":"radixai/python-gpu:$PYTHON_VERSION-cuda11.8", "with_fastapi_api": "1", "with_typer_cli": "1"}' ./template/
+          cruft create --no-input --extra-context '{"project_type": "${{ matrix.project-type }}", "project_name": "My Project", "python_version": "3.10", "__docker_image":"radixai/python-gpu:$PYTHON_VERSION-cuda11.8", "with_fastapi_api": "1", "with_typer_cli": "1"}' ./template/
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -63,6 +63,7 @@ typeguard = ">=4.2.1"
 [tool.poetry.group.dev.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
 cruft = ">=2.15.0"
 ipykernel = ">=6.29.4"
+ipython = ">=8.23.0"
 ipywidgets = ">=8.1.2"
 pdoc = ">=14.4.0"
 {%- if cookiecutter.private_package_repository_name %}


### PR DESCRIPTION
Poetry Cookiecutter already included `ipykernel` and `ipywidgets` for Jupyter notebook support in VS Code. This PR adds `ipython` to the dev dependencies to make that available in the terminal as well.

EDIT: Because ipython requires Python 3.10 or higher, this PR increases the minimum Python version in addition to adding ipython to the dev dependencies.