### PR TITLE
fix: update ruff log level

### DIFF
--- a/{{ cookiecutter.__project_name_kebab_case }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.devcontainer/devcontainer.json
@@ -54,7 +54,7 @@
                 "python.testing.pytestEnabled": true,
                 "ruff.importStrategy": "fromEnvironment",
                 {%- if cookiecutter.development_environment == "strict" %}
-                "ruff.logLevel": "warn",
+                "ruff.logLevel": "warning",
                 {%- endif %}
                 "terminal.integrated.defaultProfile.linux": "zsh",
                 "terminal.integrated.profiles.linux": {


### PR DESCRIPTION
The `warn` ruff log level we use in strict mode has been renamed to `warning`. This PR updates the setting to match the new value.