### PR TITLE
fix: Conflicting dependencies between ipython and commitizen

### DIFF
--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -63,7 +63,7 @@ typeguard = ">=4.2.1"
 [tool.poetry.group.dev.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
 cruft = ">=2.15.0"
 ipykernel = ">=6.29.4"
-ipython = ">=8.23.0"
+ipython = ">=8.18.0"
 ipywidgets = ">=8.1.2"
 pdoc = ">=14.4.0"
 {%- if cookiecutter.private_package_repository_name %}


### PR DESCRIPTION
The earlier addition of `ipython = ">=8.23.0"` conflicts with commitizen and prevents the Docker image to build successfully.

 - `commitizen` requires `questionary (>=2.0,<3.0)`.
 - `questionary (2.0.0 and 2.0.1)` depend on `prompt_toolkit (>=2.0,<=3.0.36)`.
  - `ipython (>=8.23.0)` depends on `prompt_toolkit (>=3.0.41,<3.1.0)`.

**Conflict:** `prompt_toolkit (>=3.0.41,<3.1.0)` required by `ipython (>=8.23.0)` is incompatible with `prompt_toolkit (<=3.0.36)` required by `questionary` (and thus `commitizen`).

I found that `ipython` version  `>=8.18.0` is compatible with commitizen.