### PR TITLE
feat: add Docker VS Code extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
         "vscode": {
             "extensions": [
                 "DavidAnson.vscode-markdownlint",
+                "ms-azuretools.vscode-docker",
                 "ms-python.python",
                 "tamasfe.even-better-toml",
                 "visualstudioexptteam.vscodeintellicode"

--- a/{{ cookiecutter.__project_name_kebab_case }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
                 {%- elif cookiecutter.continuous_integration == "GitLab" %}
                 "GitLab.gitlab-workflow",
                 {%- endif %}
+                "ms-azuretools.vscode-docker",
                 "ms-python.mypy-type-checker",
                 "ms-python.python",
                 "ms-toolsai.jupyter",


### PR DESCRIPTION
Add Microsoft's Docker VS Code extension by default so that we can avoid VS Code nagging you to install it on startup.