### PR TITLE
ci: expand test matrix and upgrade steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         project-type: ["app", "package"]
 
     name: Python ${{ matrix.python-version }} ${{ matrix.project-type }}
@@ -37,10 +37,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 23
 
       - name: Install @devcontainers/cli
-        run: npm install --location=global @devcontainers/cli@0.58.0
+        run: npm install --location=global @devcontainers/cli@0.72.0
 
       - name: Start Dev Container with Python ${{ matrix.python-version }}
         run: |

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 23
 
       - name: Install @devcontainers/cli
-        run: npm install --location=global @devcontainers/cli@0.58.0
+        run: npm install --location=global @devcontainers/cli@0.72.0
 
       - name: Start Dev Container
         run: |
@@ -42,6 +42,6 @@ jobs:
         run: devcontainer exec --workspace-folder . poe test
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: reports/coverage.xml

--- a/{{ cookiecutter.__project_name_kebab_case }}/.gitlab-ci.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
       - .npm_cache
   before_script:
     - mkdir -p .apk_cache && apk add --cache-dir .apk_cache npm
-    - npm install --cache .npm_cache --global --prefer-offline @devcontainers/cli@0.58.0
+    - npm install --cache .npm_cache --global --prefer-offline @devcontainers/cli@0.72.0
 
 # Build the Dev Container.
 Build:


### PR DESCRIPTION
Changes:
1. Expand test matrix to include Python 3.11 and 3.13.
2. Upgrade all CI dependencies to their latest versions.