### PR TITLE
feat: add support for mise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ notebooks/
 # macOS
 .DS_Store
 
+# mise
+mise.local.toml
+
 # mypy
 .dmypy.json
 .mypy_cache/

--- a/{{ cookiecutter.__project_name_kebab_case }}/.gitignore
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.gitignore
@@ -30,6 +30,9 @@ notebooks/
 # macOS
 .DS_Store
 
+# mise
+mise.local.toml
+
 # mypy
 .dmypy.json
 .mypy_cache/


### PR DESCRIPTION
[Mise](https://github.com/jdx/mise) is an alternative for [pyenv](https://github.com/pyenv/pyenv) + [direnv](https://github.com/direnv/direnv), and can also manage other tools.