### PR TITLE
feat: upgrade to Poetry v2.0

### DIFF
--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
@@ -40,8 +40,3 @@ jobs:
 
       - name: Test {{ cookiecutter.project_type }}
         run: devcontainer exec --workspace-folder . poe test
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          files: reports/coverage.xml

--- a/{{ cookiecutter.__project_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__project_name_kebab_case }}/Dockerfile
@@ -37,7 +37,7 @@ FROM base AS poetry
 USER root
 
 # Install Poetry in separate venv so it doesn't pollute the main venv.
-ENV POETRY_VERSION 1.8.0
+ENV POETRY_VERSION 2.0.1
 ENV POETRY_VIRTUAL_ENV /opt/poetry-env
 RUN --mount=type=cache,target=/root/.cache/pip/ \
     python -m venv $POETRY_VIRTUAL_ENV && \
@@ -92,7 +92,7 @@ RUN mkdir -p /opt/build/poetry/ && cp poetry.lock /opt/build/poetry/ && \
     mkdir -p /opt/build/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /opt/build/git/
 
 # Configure the non-root user's shell.
-ENV ANTIDOTE_VERSION 1.8.6
+ENV ANTIDOTE_VERSION 1.9.7
 RUN git clone --branch v$ANTIDOTE_VERSION --depth=1 https://github.com/mattmc3/antidote.git ~/.antidote/ && \
     echo 'zsh-users/zsh-syntax-highlighting' >> ~/.zsh_plugins.txt && \
     echo 'zsh-users/zsh-autosuggestions' >> ~/.zsh_plugins.txt && \

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -2,45 +2,47 @@
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry]  # https://python-poetry.org/docs/pyproject/
+[project]  # https://packaging.python.org/en/latest/specifications/pyproject-toml/
 name = "{{ cookiecutter.__project_name_kebab_case }}"
 version = "0.0.0"
 description = "{{ cookiecutter.project_description }}"
-authors = ["{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>"]
 readme = "README.md"
-repository = "{{ cookiecutter.project_url }}"
-{%- if cookiecutter.with_conventional_commits|int %}
+license-files = ["LICENSE*"]
+authors = ["{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>"]
+requires-python = ">={{ cookiecutter.python_version }},<4.0"
 
-[tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
-bump_message = "bump(release): v$current_version → v$new_version"
-tag_format = "v$version"
-update_changelog_on_bump = true
-version_provider = "poetry"
+[project.urls]  # https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels
+homepage = "{{ cookiecutter.project_url }}"
+source = "{{ cookiecutter.project_url }}"
+{%- if cookiecutter.with_conventional_commits|int %}
+changelog = "{{ cookiecutter.project_url }}/{% if cookiecutter.continuous_integration == "GitLab" %}-/{% endif %}blob/main/CHANGELOG.md"
 {%- endif %}
+releasenotes = "{{ cookiecutter.project_url }}/{% if cookiecutter.continuous_integration == "GitLab" %}-/{% endif %}releases"
+documentation = "{{ cookiecutter.project_url }}"
+issues = "{{ cookiecutter.project_url }}/{% if cookiecutter.continuous_integration == "GitLab" %}-/{% endif %}issues"
+dependencies = [
+  {%- if cookiecutter.with_fastapi_api|int %}
+  "coloredlogs (>=15.0.1)",
+  "fastapi[all] (>=0.110.1)",
+  "gunicorn (>=21.2.0)",
+  {%- endif %}
+  {%- if cookiecutter.project_type == "app" %}
+  "poethepoet (>=0.25.0)",
+  {%- endif %}
+  {%- if cookiecutter.with_typer_cli|int %}
+  "typer[all] (>=0.12.0)",
+  {%- endif %}
+  {%- if cookiecutter.with_fastapi_api|int %}
+  "uvicorn[standard] (>=0.29.0)",
+  {%- endif %}
+]
 {%- if cookiecutter.with_typer_cli|int %}
 
-[tool.poetry.scripts]  # https://python-poetry.org/docs/pyproject/#scripts
+[project.scripts]  # https://python-poetry.org/docs/pyproject/#scripts
 {{ cookiecutter.__project_name_kebab_case }} = "{{ cookiecutter.__project_name_snake_case }}.cli:app"
 {%- endif %}
 
-[tool.poetry.dependencies]  # https://python-poetry.org/docs/dependency-specification/
-{%- if cookiecutter.with_fastapi_api|int %}
-coloredlogs = ">=15.0.1"
-fastapi = { extras = ["all"], version = ">=0.110.1" }
-gunicorn = ">=21.2.0"
-{%- endif %}
-{%- if cookiecutter.project_type == "app" %}
-poethepoet = ">=0.25.0"
-{%- endif %}
-python = ">={{ cookiecutter.python_version }},<4.0"
-{%- if cookiecutter.with_typer_cli|int %}
-typer = { extras = ["all"], version = ">=0.12.0" }
-{%- endif %}
-{%- if cookiecutter.with_fastapi_api|int %}
-uvicorn = { extras = ["standard"], version = ">=0.29.0" }
-{%- endif %}
-
-[tool.poetry.group.test.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
+[tool.poetry.group.test.dependencies]  # https://python-poetry.org/docs/managing-dependencies#dependency-groups
 {%- if cookiecutter.with_conventional_commits|int %}
 commitizen = ">=3.21.3"
 {%- endif %}
@@ -60,7 +62,7 @@ shellcheck-py = ">=0.10.0.1"
 typeguard = ">=4.2.1"
 {%- endif %}
 
-[tool.poetry.group.dev.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
+[tool.poetry.group.dev.dependencies]  # https://python-poetry.org/docs/managing-dependencies#dependency-groups
 cruft = ">=2.15.0"
 ipykernel = ">=6.29.4"
 ipython = ">=8.18.0"
@@ -76,6 +78,14 @@ priority = "default"
 name = "{{ cookiecutter.private_package_repository_name|slugify }}"
 url = "{{ cookiecutter.private_package_repository_url }}"
 priority = "explicit"
+{%- endif %}
+{%- if cookiecutter.with_conventional_commits|int %}
+
+[tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
+bump_message = "bump(release): v$current_version → v$new_version"
+tag_format = "v$version"
+update_changelog_on_bump = true
+version_provider = "poetry"
 {%- endif %}
 
 [tool.coverage.report]  # https://coverage.readthedocs.io/en/latest/config.html#report
@@ -128,7 +138,8 @@ filterwarnings = ["error", "ignore::DeprecationWarning"]
 testpaths = ["src", "tests"]
 xfail_strict = true
 
-[tool.ruff]  # https://github.com/charliermarsh/ruff
+[tool.ruff]  # https://docs.astral.sh/ruff/settings/
+docstring-code-format = true
 fix = true
 line-length = 100
 src = ["src", "tests"]


### PR DESCRIPTION
Changes:
- Upgrade to [Poetry v2.0](https://python-poetry.org/blog/announcing-poetry-2.0.0/)
- Upgrade antidote to v1.9.7
- Small improvement to the Ruff config
- Remove codecov