### PR TITLE
fix: configure commitizen to use PEP 621

### DIFF
--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -82,10 +82,10 @@ priority = "explicit"
 {%- if cookiecutter.with_conventional_commits|int %}
 
 [tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
-bump_message = "bump(release): v$current_version → v$new_version"
+bump_message = "bump: v$current_version → v$new_version"
 tag_format = "v$version"
 update_changelog_on_bump = true
-version_provider = "poetry"
+version_provider = "pep621"
 {%- endif %}
 
 [tool.coverage.report]  # https://coverage.readthedocs.io/en/latest/config.html#report


### PR DESCRIPTION
With the upgrade to Poetry v2.0 in #266, the project's version number is now maintained under the `[project]` section instead of the `[tool.poetry]` section. This PR updates Commitizen's configuration so that it manages the version at the new location.