### PR TITLE
fix: use new `ENV key=value` format in Dockerfile

### DIFF
--- a/{{ cookiecutter.__project_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__project_name_kebab_case }}/Dockerfile
@@ -9,8 +9,8 @@ RUN rm /etc/apt/apt.conf.d/docker-clean
 # Configure Python to print tracebacks on crash [1], and to not buffer stdout and stderr [2].
 # [1] https://docs.python.org/3/using/cmdline.html#envvar-PYTHONFAULTHANDLER
 # [2] https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED
-ENV PYTHONFAULTHANDLER 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONFAULTHANDLER=1
+ENV PYTHONUNBUFFERED=1
 {%- endif %}
 
 # Create a non-root user and switch to it [1].
@@ -23,8 +23,8 @@ RUN groupadd --gid $GID user && \
 USER user
 
 # Create and activate a virtual environment.
-ENV VIRTUAL_ENV /opt/{{ cookiecutter.__project_name_kebab_case }}-env
-ENV PATH $VIRTUAL_ENV/bin:$PATH
+ENV VIRTUAL_ENV=/opt/{{ cookiecutter.__project_name_kebab_case }}-env
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
 RUN python -m venv $VIRTUAL_ENV
 
 # Set the working directory.
@@ -37,8 +37,8 @@ FROM base AS poetry
 USER root
 
 # Install Poetry in separate venv so it doesn't pollute the main venv.
-ENV POETRY_VERSION 2.0.1
-ENV POETRY_VIRTUAL_ENV /opt/poetry-env
+ENV POETRY_VERSION=2.0.1
+ENV POETRY_VIRTUAL_ENV=/opt/poetry-env
 RUN --mount=type=cache,target=/root/.cache/pip/ \
     python -m venv $POETRY_VIRTUAL_ENV && \
     $POETRY_VIRTUAL_ENV/bin/pip install poetry~=$POETRY_VERSION && \
@@ -93,7 +93,7 @@ RUN mkdir -p /opt/build/poetry/ && cp poetry.lock /opt/build/poetry/ && \
     mkdir -p /opt/build/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /opt/build/git/
 
 # Configure the non-root user's shell.
-ENV ANTIDOTE_VERSION 1.9.7
+ENV ANTIDOTE_VERSION=1.9.7
 RUN git clone --branch v$ANTIDOTE_VERSION --depth=1 https://github.com/mattmc3/antidote.git ~/.antidote/ && \
     echo 'zsh-users/zsh-syntax-highlighting' >> ~/.zsh_plugins.txt && \
     echo 'zsh-users/zsh-autosuggestions' >> ~/.zsh_plugins.txt && \


### PR DESCRIPTION
This PR fixes this Docker warning:
```
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
```